### PR TITLE
Fix windows OS related issues

### DIFF
--- a/integration-tests/Configure_Product.py
+++ b/integration-tests/Configure_Product.py
@@ -17,6 +17,8 @@
 from xml.etree import ElementTree as ET
 from zipfile import ZipFile
 import os
+import stat
+import sys
 import yaml
 from pathlib import Path
 import shutil
@@ -31,6 +33,7 @@ product_name = None
 product_home_path = None
 distribution_storage = None
 database_config = None
+product_storage = None
 workspace = None
 lib_location = None
 sql_driver_location = None
@@ -43,58 +46,58 @@ carbon_name = "carbon.zip"
 value_tag = "{http://maven.apache.org/POM/4.0.0}value"
 artifact_id_of_surefire_plugin = "maven-surefire-plugin"
 
-
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
-def copy_product(source, destination):
-    Path(destination).mkdir(parents=True, exist_ok=True)
-    shutil.copy(source, destination)
+class ZipfileLongPaths(ZipFile):
+    def _extract_member(self, member, targetpath, pwd):
+        targetpath = winapi_path(targetpath)
+        return ZipFile._extract_member(self, member, targetpath, pwd)
 
 
-def extract_distribution(path):
-    with ZipFile(path, "r") as zip_ref:
-        zip_ref.extractall(distribution_storage)
+def winapi_path(dos_path, encoding=None):
+    path = os.path.abspath(dos_path)
+
+    if path.startswith("\\\\"):
+        path = "\\\\?\\UNC\\" + path[2:]
+    else:
+        path = "\\\\?\\" + path
+
+    return path
 
 
-def get_all_file_paths(directory):
-    # initializing empty file paths list
-    file_paths = []
-
-    # crawling through directory and subdirectories
-    for root, directories, files in os.walk(directory):
-        for filename in files:
-            # join the two strings in order to form the full filepath.
-            filepath = os.path.join(root, filename)
-            file_paths.append(filepath)
-
-    # returning all file paths
-    return file_paths
+def on_rm_error(func, path, exc_info):
+    os.chmod(path, stat.S_IWRITE)
+    os.unlink(path)
 
 
-def compress_distribution(zip_path):
-    # calling function to get all file paths in the directory
-    file_paths = get_all_file_paths(product_home_path)
-    logger.info("Start product compressing")
-
-    # writing files to a zipfile
-    with ZipFile(zip_path, 'w') as zip:
-        # writing each file one by one
-        for file in file_paths:
-            zip.write(file, file.replace(str(distribution_storage), ''))
-
-    logger.info('All files zipped successfully!')
-
-
-def delete_extracted_product():
-    logger.info("deleting extracted product")
-    shutil.rmtree(Path(distribution_storage / product_name))
+def extract_product(path):
+    if Path.exists(path):
+        logger.info("Extracting the product  into " + str(product_storage))
+        if sys.platform.startswith('win'):
+            with ZipfileLongPaths(path, "r") as zip_ref:
+                zip_ref.extractall(product_storage)
+        else:
+            with ZipFile(path, "r") as zip_ref:
+                zip_ref.extractall(product_storage)
+    else:
+        raise FileNotFoundError("File is not found to extract, file path: " + str(path))
 
 
-def copy_jar_file():
+def compress_distribution(distribution_path, root_dir):
+    if not Path.exists(distribution_path):
+        Path(distribution_path).mkdir(parents=True, exist_ok=True)
+
+    shutil.make_archive(distribution_path, "zip", root_dir)
+
+
+def copy_jar_file(source, destination):
     logger.info('sql driver is coping to the product lib folder')
-    shutil.copy(Path(database_config['sql_driver_location']), Path(product_home_path / lib_location))
+    if sys.platform.startswith('win'):
+        source = winapi_path(source)
+        destination = winapi_path(destination)
+    shutil.copy(source, destination)
 
 
 def read_config_file():
@@ -103,19 +106,21 @@ def read_config_file():
     global product_home_path
     global database_config
     global product_name
-    global workspace
+    global product_storage
     global lib_location
     global repository_name
     global pom_file_paths
+    global workspace
     with open("config.yml", 'r') as ymlfile:
         cfg = yaml.load(ymlfile)
 
     datasource_paths = cfg['datasource_paths']
     repository_name = cfg['repository_name']
     lib_location = cfg['lib_location']
+    product_storage = cfg['product_storage']
     workspace = cfg['workspace']
     distribution_storage = Path(workspace + "/" + repository_name + "/" + cfg['distribution_storage'])
-    product_home_path = Path(distribution_storage / cfg['product_name'])
+    product_home_path = Path(product_storage + "/" + cfg['product_name'])
     database_config = cfg['database']
     product_name = cfg['product_name']
     pom_file_paths = cfg['pom_file_paths']
@@ -131,7 +136,7 @@ def write_to_config_file():
             yaml_file.write(yaml.dump(cfg, default_flow_style=False))
 
 
-def modify_distibution_name(element):
+def modify_distribution_name(element):
     temp = element.text.split("/")
     temp[-1] = product_name + zip_file_extension
     return '/'.join(temp)
@@ -140,6 +145,8 @@ def modify_distibution_name(element):
 def modify_pom_files():
     for pom in pom_file_paths:
         file_path = Path(workspace + "/" + repository_name + "/" + pom)
+        if sys.platform.startswith('win'):
+            file_path = winapi_path(file_path)
         logger.info("Modifying pom file: " + str(file_path))
         ET.register_namespace('', ns['d'])
         artifact_tree = ET.parse(file_path)
@@ -152,13 +159,13 @@ def modify_pom_files():
                 configuration = plugin.find('d:configuration', ns)
                 system_properties = configuration.find('d:systemProperties', ns)
                 for neighbor in system_properties.iter(ns['d'] + carbon_name):
-                    neighbor.text = modify_distibution_name(neighbor)
+                    neighbor.text = modify_distribution_name(neighbor)
                 for prop in system_properties:
                     name = prop.find('d:name', ns)
                     if name is not None and name.text == carbon_name:
                         for data in prop:
                             if data.tag == value_tag:
-                                data.text = modify_distibution_name(data)
+                                data.text = modify_distribution_name(data)
                 break
         artifact_tree.write(file_path)
 
@@ -166,6 +173,8 @@ def modify_pom_files():
 def modify_datasources():
     for data_source in datasource_paths:
         file_path = Path(product_home_path / data_source)
+        if sys.platform.startswith('win'):
+            file_path = winapi_path(file_path)
         logger.info("Modifying datasource: " + str(file_path))
         artifact_tree = ET.parse(file_path)
         artifarc_root = artifact_tree.getroot()
@@ -194,22 +203,25 @@ def modify_datasources():
 def main():
     try:
         read_config_file()
+        zip_name = product_name + zip_file_extension
+        product_location = Path(product_storage + "/" + zip_name)
+        configured_product_path = Path(distribution_storage / product_name)
         if pom_file_paths is not None:
             modify_pom_files()
         else:
             logger.info("pom file paths are not defined in the config file")
-        zip_name = product_name + zip_file_extension
-        product_location = Path(workspace + "/" + zip_name)
-        copy_product(product_location, distribution_storage)
-        extract_distribution(Path(distribution_storage / zip_name))
-        copy_jar_file()
+        extract_product(product_location)
+        copy_jar_file(Path(database_config['sql_driver_location']), Path(product_home_path / lib_location))
         if datasource_paths is not None:
             modify_datasources()
         else:
             logger.info("datasource paths are not defined in the config file")
         write_to_config_file()
-        compress_distribution(Path(distribution_storage / zip_name))
-        delete_extracted_product()
+        os.remove(str(product_location))
+        compress_distribution(configured_product_path, product_storage)
+        shutil.rmtree(configured_product_path, onerror=on_rm_error)
+    except FileNotFoundError as e:
+        logger.error("Error occurred while finding files", exc_info=True)
     except IOError as e:
         logger.error("Error occurred while accessing files", exc_info=True)
     except Exception as e:

--- a/integration-tests/config.yml
+++ b/integration-tests/config.yml
@@ -34,6 +34,7 @@
 #product_name: product-x
 #repository_name: product-x
 #workspace: /home/TG/workspace
+#product_storage : /home/TG/workspace/storage
 #
 ####################################################
 
@@ -50,3 +51,4 @@ pom_file_paths:
 product_name:
 repository_name:
 workspace:
+product_storage :


### PR DESCRIPTION
## Purpose
> The purpose of this PR is to fix Windows OS related issues and improving the product configuring.

## Goals
> Regular DOS paths are limited to MAX_PATH (260) characters, including the string's terminating NUL character.  Therefore if we try to access file path which has more than 260 characters for its path, windows throw IOError. In order to exceed this limit, we can use extended-length paths. Hence in order to fix this issue checked the OS and, if OS is windows then modify the path to extended-length path.

## Approach
> N/A

## User stories
>  N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> OS UBUNTU 18.04 and Windows 10
 
## Learning
> N/A