### PR TITLE
Change to grep from both properties file location

### DIFF
--- a/integration-tests/do-run.sh
+++ b/integration-tests/do-run.sh
@@ -126,19 +126,19 @@ FILE1=${WORKSPACE_DIR}/infrastructure.properties
 FILE2=${WORKSPACE_DIR}/testplan-props.properties
 
 #### User Variables
-GIT_LOCATION=$(grep -i 'gitURL' ${FILE2}  | cut -f2 -d'=')
-GIT_BRANCH=$(grep -i 'gitBranch' ${FILE2}  | cut -f2 -d'=')
+GIT_LOCATION=$(grep -i 'gitURL' ${FILE2} ${FILE1}  | cut -f2 -d'=')
+GIT_BRANCH=$(grep -i 'gitBranch' ${FILE2} ${FILE1}  | cut -f2 -d'=')
 
-USERNAME=$(grep -i 'DatabaseUser' ${FILE1}  | cut -f2 -d'=')
-DB_HOST=$(grep -i 'DatabaseHost' ${FILE1}  | cut -f2 -d'=')
-DB_PORT=$(grep -i 'DatabasePort' ${FILE1}  | cut -f2 -d'=')
+USERNAME=$(grep -i 'DatabaseUser' ${FILE1} ${FILE2} | cut -f2 -d'=')
+DB_HOST=$(grep -i 'DatabaseHost' ${FILE1} ${FILE2} | cut -f2 -d'=')
+DB_PORT=$(grep -i 'DatabasePort' ${FILE1} ${FILE2} | cut -f2 -d'=')
 #DB_ENGINE=$(echo $config_database_..)
-DB_VERSION=$(grep -i 'DBEngineVersion' ${FILE2}  | cut -f2 -d'=')
-DB_TYPE=$(grep -i 'DBEngine' ${FILE2}  | cut -f2 -d'=')
+DB_VERSION=$(grep -i 'DBEngineVersion' ${FILE2} ${FILE1} | cut -f2 -d'=')
+DB_TYPE=$(grep -i 'DBEngine' ${FILE2} ${FILE1} | cut -f2 -d'=')
 
 ## MySQL connection details
-MYSQL_USERNAME=$(grep -i 'DatabaseUser' ${FILE1}  | cut -f2 -d'=')
-MYSQL_PASSWORD=$(grep -i 'DatabasePassword' ${FILE1}  | cut -f2 -d'=')
+MYSQL_USERNAME=$(grep -i 'DatabaseUser' ${FILE1} ${FILE2} | cut -f2 -d'=')
+MYSQL_PASSWORD=$(grep -i 'DatabasePassword' ${FILE1} ${FILE2} | cut -f2 -d'=')
 
 ## databases
 CARBON_DB="WSO2_CARBON_DB"

--- a/integration-tests/run-scenario.sh
+++ b/integration-tests/run-scenario.sh
@@ -24,13 +24,13 @@ FILE2=${DIR}/testplan-props.properties
 PROP_KEY=sshKeyFileLocation    #pem file
 PROP_USER=user              #OS name e.g. centos
 PROP_HOST=WSO2PublicIP      #host IP
-PROP_REMOTE_DIR=RemoteWorkspaceDirPosix
+PROP_REMOTE_DIR=REMOTE_WORKSPACE_DIR_UNIX
 
-REM_DIR=`cat ${FILE2} | grep -w "$PROP_REMOTE_DIR" | cut -d'=' -f2`
-key_pem=`cat ${FILE1} | grep -w "$PROP_KEY" | cut -d'=' -f2`
-#user=`cat ${FILE2} | grep -w "$PROP_USER" | cut -d'=' -f2`
+REM_DIR=`grep -w "$PROP_REMOTE_DIR" ${FILE1} ${FILE2} | cut -d'=' -f2`
+key_pem=`grep -w "$PROP_KEY" ${FILE1} ${FILE2} | cut -d'=' -f2`
+#user=`cat ${FILE2} | grep -w "$PROP_USER" ${FILE1} ${FILE2} | cut -d'=' -f2`
 user=centos
-host=`cat ${FILE1} | grep -w "$PROP_HOST" | cut -d'=' -f2`
+host=`grep -w "$PROP_HOST" ${FILE1} ${FILE2} | cut -d'=' -f2`
 
 scp -o StrictHostKeyChecking=no -i ${key_pem} do-run.sh ${user}@${host}:${REM_DIR}
 


### PR DESCRIPTION
- This was read from one file, and if property value exist in other file, run-scenario.sh missing the value to pass
- Change the grep to read from both properties files