### PR TITLE
Add default db username property

### DIFF
--- a/integration-tests/const.py
+++ b/integration-tests/const.py
@@ -36,6 +36,7 @@ DB_AM_DB = 'WSO2AM_DB'
 DB_STAT_DB = 'WSO2AM_STATS_DB'
 DB_MB_DB = 'WSO2_MB_STORE_DB'
 DB_METRICS_DB = 'WSO2_METRICS_DB'
+DEFAULT_DB_USERNAME = "wso2carbon"
 DB_META_DATA = {
     "MYSQL": {"prefix": "jdbc:mysql://", "driverClassName": "com.mysql.jdbc.Driver", "jarName": "mysql.jar"},
     "SQLSERVER-SE": {"prefix": "jdbc:jtds:sqlserver://", "driverClassName": "net.sourceforge.jtds.jdbc.Driver",

--- a/integration-tests/run-intg-test.py
+++ b/integration-tests/run-intg-test.py
@@ -28,7 +28,7 @@ import requests
 import configure_product as cp
 from subprocess import Popen, PIPE
 from const import TEST_PLAN_PROPERTY_FILE_NAME, INFRA_PROPERTY_FILE_NAME, LOG_FILE_NAME, DB_META_DATA, \
-    PRODUCT_STORAGE_DIR_NAME, DB_CARBON_DB, DB_AM_DB, DB_STAT_DB, DB_MB_DB, DB_METRICS_DB
+    PRODUCT_STORAGE_DIR_NAME, DB_CARBON_DB, DB_AM_DB, DB_STAT_DB, DB_MB_DB, DB_METRICS_DB, DEFAULT_DB_USERNAME
 
 git_repo_url = None
 git_branch = None
@@ -111,8 +111,7 @@ def read_proprty_files():
 def validate_property_radings():
     if None in (
             db_engine_version, git_repo_url, product_id, git_branch, product_dist_download_api, sql_driver_location,
-            db_host,
-            db_port, db_username, db_password):
+            db_host, db_port, db_password):
         return False
     return True
 
@@ -387,8 +386,12 @@ def construct_db_config():
         database_config["password"] = db_password
         database_config["sql_driver_location"] = sql_driver_location + "/" + db_meta_data["jarName"]
         database_config["url"] = construct_url(db_meta_data["prefix"])
-        database_config["user"] = db_username
         database_config["db_engine"] = db_engine
+        if db_username is None:
+            database_config["user"] = DEFAULT_DB_USERNAME
+        else:
+            database_config["user"] = db_username
+
     else:
         raise BaseException(
             "DB config parsing is failed. DB engine name in the property file doesn't match with the constant: " + str(


### PR DESCRIPTION
## Purpose
> The purpose of this PR is to fix the DB configuring issue. 

## Goals
> When we running integration tests against APIM product, sometimes DBUsername property doesn't contain in the property file. The property file is auto-generated one, therefore if the DBUsername property doesn't contain in the property file, python scripts will take the default DB username and do the configuration. 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> OS - UBUNTU-18.04