### PR TITLE
Modified run-scenario shell script to work with a Windows instance

### DIFF
--- a/integration-tests/run-scenario.sh
+++ b/integration-tests/run-scenario.sh
@@ -30,7 +30,7 @@ FILE8=intg-test-runner.bat
 PROP_KEY=sshKeyFileLocation      #pem file
 PROP_OS=OS                       #OS name e.g. centos
 PROP_HOST=WSO2PublicIP           #host IP
-PROP_INSTANCE_ID=WSO2InstanceId  #instance ID
+PROP_INSTANCE_ID=WSO2InstanceId  #Physical ID (Resource ID) of WSO2 EC2 Instance
 
 #----------------------------------------------------------------------
 # getting data from databuckets
@@ -45,11 +45,11 @@ host=`grep -w "$PROP_HOST" ${FILE1} ${FILE2} | cut -d'=' -f2`
 CONNECT_RETRY_COUNT=20
 
 #=== FUNCTION ==================================================================
-# NAME: request_password
+# NAME: request_ec2_password
 # DESCRIPTION: Request password of Windows instance from AWS using the key file. 
-# PARAMETER 1: ID of the Windows instance
+# PARAMETER 1: Physical-ID of the EC2 instance
 #===============================================================================
-request_password() {
+request_ec2_password() {
   instance_id=$1
   echo "Retrieving password for Windows instance from AWS for instance id ${instance_id}" 
   x=1;
@@ -70,7 +70,7 @@ request_password() {
       exit
     fi
  
-    sleep 2 # wait for 2 second before check again
+    sleep 10 # wait for 10 second before check again
     x=$((x+1))
   done 
 }
@@ -132,7 +132,7 @@ if [ "${os}" = "Windows" ]; then
   echo "Waiting 4 minutes till Windows instance is configured. "
   sleep 4m #wait 4 minutes till Windows instance is configured and able to receive password using key file.
   
-  request_password $instance_id
+  request_ec2_password $instance_id
 
   sshpass -p "${password}" scp -o StrictHostKeyChecking=no ${FILE1} ${user}@${host}:${REM_DIR}
   sshpass -p "${password}" scp -o StrictHostKeyChecking=no ${FILE2} ${user}@${host}:${REM_DIR}

--- a/integration-tests/run-scenario.sh
+++ b/integration-tests/run-scenario.sh
@@ -57,11 +57,11 @@ request_password() {
 
   while [ "$password" == "" ] ; do
     #Request password from AWS
-    passwordJson=$(aws ec2 get-password-data --instance-id "${instance_id}" --priv-launch-key /home/pasindu/TestGrid/keys/testgrid-key.pem)
+    responseJson=$(aws ec2 get-password-data --instance-id "${instance_id}" --priv-launch-key ${key_pem})
 
     #Validate JSON
-    if [ $(echo $passwordJson | python -c "import sys,json;json.loads(sys.stdin.read());print 'Valid'") == "Valid" ]; then
-      password=$(python3 -c "import sys, json;print(($passwordJson)['PasswordData'])")
+    if [ $(echo $responseJson | python -c "import sys,json;json.loads(sys.stdin.read());print 'Valid'") == "Valid" ]; then
+      password=$(python3 -c "import sys, json;print(($responseJson)['PasswordData'])")
       echo "Password received!"
     fi
 
@@ -133,7 +133,6 @@ if [ "${os}" = "Windows" ]; then
   sleep 4m #wait 4 minutes till Windows instance is configured and able to receive password using key file.
   
   request_password $instance_id
-  REM_DIR="c:/testgrid/workspace"
 
   sshpass -p "${password}" scp -o StrictHostKeyChecking=no ${FILE1} ${user}@${host}:${REM_DIR}
   sshpass -p "${password}" scp -o StrictHostKeyChecking=no ${FILE2} ${user}@${host}:${REM_DIR}

--- a/integration-tests/run-scenario.sh
+++ b/integration-tests/run-scenario.sh
@@ -25,61 +25,153 @@ FILE4=configure_product.py
 FILE5=const.py
 FILE6=requirements.txt
 FILE7=intg-test-runner.sh
+FILE8=intg-test-runner.bat
 
-PROP_KEY=sshKeyFileLocation    #pem file
-PROP_USER=user              #OS name e.g. centos
-PROP_HOST=WSO2PublicIP      #host IP
-PROP_REMOTE_DIR=REMOTE_WORKSPACE_DIR_UNIX
+PROP_KEY=sshKeyFileLocation      #pem file
+PROP_OS=OS                       #OS name e.g. centos
+PROP_HOST=WSO2PublicIP           #host IP
+PROP_INSTANCE_ID=WSO2InstanceId  #instance ID
 
-REM_DIR=`grep -w "$PROP_REMOTE_DIR" ${FILE1} ${FILE2} | cut -d'=' -f2`
+#----------------------------------------------------------------------
+# getting data from databuckets
+#----------------------------------------------------------------------
 key_pem=`grep -w "$PROP_KEY" ${FILE1} ${FILE2} | cut -d'=' -f2`
+os=`cat ${FILE2} | grep -w "$PROP_OS" ${FILE1} | cut -d'=' -f2`
 #user=`cat ${FILE2} | grep -w "$PROP_USER" ${FILE1} ${FILE2} | cut -d'=' -f2`
-user=centos
+instance_id=`cat ${FILE2} | grep -w "$PROP_INSTANCE_ID" ${FILE1} ${FILE2} | cut -d'=' -f2`
+user=''
+password=''
 host=`grep -w "$PROP_HOST" ${FILE1} ${FILE2} | cut -d'=' -f2`
 CONNECT_RETRY_COUNT=20
 
-wait_for_port() {
-host=$1
-port=$2
-x=0;
-retry_count=$CONNECT_RETRY_COUNT;
-echo "Wait port: ${1}:${2}" 
-while ! nc -z $host $port; do
-  sleep 2 # wait for 2 second before check again
-  echo -n "."
-  if [ $x = $retry_count ]; then
-    echo "port never opened."
-    exit 1
-  fi
-x=$((x+1))
-done
+#=== FUNCTION ==================================================================
+# NAME: request_password
+# DESCRIPTION: Request password of Windows instance from AWS using the key file. 
+# PARAMETER 1: ID of the Windows instance
+#===============================================================================
+request_password() {
+  instance_id=$1
+  echo "Retrieving password for Windows instance from AWS for instance id ${instance_id}" 
+  x=1;
+  retry_count=$CONNECT_RETRY_COUNT;
 
+  while [ "$password" == "" ] ; do
+    #Request password from AWS
+    passwordJson=$(aws ec2 get-password-data --instance-id "${instance_id}" --priv-launch-key /home/pasindu/TestGrid/keys/testgrid-key.pem)
+
+    #Validate JSON
+    if [ $(echo $passwordJson | python -c "import sys,json;json.loads(sys.stdin.read());print 'Valid'") == "Valid" ]; then
+      password=$(python3 -c "import sys, json;print(($passwordJson)['PasswordData'])")
+      echo "Password received!"
+    fi
+
+    if [ "$x" = "$retry_count" ]; then
+      echo "Password never received for instance with id ${instance_id}. Hence skipping test execution!"
+      exit
+    fi
+ 
+    sleep 2 # wait for 2 second before check again
+    x=$((x+1))
+  done 
 }
 
+#=== FUNCTION ==================================================================
+# NAME: wait_for_port
+# DESCRIPTION: Check if the port is opened till the time-out occurs
+# PARAMETER 1: Host name
+# PARAMETER 2: Port number
+#===============================================================================
+wait_for_port() {
+  host=$1
+  port=$2
+  x=1;
+  retry_count=$CONNECT_RETRY_COUNT;
+  echo "Wait port: ${1}:${2}" 
+  while ! nc -z $host $port; do
+    sleep 2 # wait for 2 second before check again
+    echo -n "."
+    if [ $x = $retry_count ]; then
+      echo "port never opened."
+      exit 1
+    fi
+  x=$((x+1))
+  done
+}
+
+#----------------------------------------------------------------------
+# select default username and remote directory based on the OS
+#----------------------------------------------------------------------
+case "${os}" in
+   "CentOS") 
+    	user=centos
+        PROP_REMOTE_DIR=REMOTE_WORKSPACE_DIR_UNIX ;;
+   "Windows")
+    	user=Administrator
+        PROP_REMOTE_DIR=REMOTE_WORKSPACE_DIR_WINDOWS ;;
+   "UBUNTU") 
+        user=ubuntu
+        PROP_REMOTE_DIR=REMOTE_WORKSPACE_DIR_UNIX ;;
+esac
+
+REM_DIR=`grep -w "$PROP_REMOTE_DIR" ${FILE1} ${FILE2} | cut -d'=' -f2`
+
+#----------------------------------------------------------------------
+# wait till port 22 is opened for SSH
+#----------------------------------------------------------------------
 wait_for_port ${host} 22 
 
-ssh -o StrictHostKeyChecking=no -i ${key_pem} ${user}@${host} mkdir -p ${REM_DIR}
+#----------------------------------------------------------------------
+# execute commands based on the OS of the instance
+# Steps followed;
+# 1. SSH and make the directory.
+# 2. Copy necessary files to the instance.
+# 3. Execute scripts at the instance.
+# 4. Retrieve reports from the instance.
+#----------------------------------------------------------------------
+if [ "${os}" = "Windows" ]; then
+  echo "Waiting 4 minutes till Windows instance is configured. "
+  sleep 4m #wait 4 minutes till Windows instance is configured and able to receive password using key file.
+  
+  request_password $instance_id
+  REM_DIR="c:/testgrid/workspace"
 
-scp -o StrictHostKeyChecking=no -i ${key_pem} ${FILE1} ${user}@${host}:${REM_DIR}
+  sshpass -p "${password}" scp -o StrictHostKeyChecking=no ${FILE1} ${user}@${host}:${REM_DIR}
+  sshpass -p "${password}" scp -o StrictHostKeyChecking=no ${FILE2} ${user}@${host}:${REM_DIR}
+  sshpass -p "${password}" scp -o StrictHostKeyChecking=no ${FILE3} ${user}@${host}:${REM_DIR}
+  sshpass -p "${password}" scp -o StrictHostKeyChecking=no ${FILE4} ${user}@${host}:${REM_DIR}
+  sshpass -p "${password}" scp -o StrictHostKeyChecking=no ${FILE5} ${user}@${host}:${REM_DIR}
+  sshpass -p "${password}" scp -o StrictHostKeyChecking=no ${FILE6} ${user}@${host}:${REM_DIR}
+  sshpass -p "${password}" scp -o StrictHostKeyChecking=no ${FILE8} ${user}@${host}:${REM_DIR}
+  
+  echo "=== Files copied successfully ==="
+  echo "Execution begins.. "
 
-scp -o StrictHostKeyChecking=no -i ${key_pem} ${FILE2} ${user}@${host}:${REM_DIR}
+  sshpass -p "${password}" ssh -o StrictHostKeyChecking=no ${user}@${host} call "${REM_DIR}/${FILE8}" ${REM_DIR}
+  echo "=== End of execution ==="
+  echo "Retrieving reports from instance.. "
+  sshpass -p "${password}" scp -o StrictHostKeyChecking=no ${user}@${host}:${REM_DIR}/product-apim/modules/integration/tests-integration/tests-backend/target/surefire-reports ${DIR}
+  sshpass -p "${password}" scp -o StrictHostKeyChecking=no ${user}@${host}:${REM_DIR}/product-apim/modules/integration/tests-integration/tests-backend/target/logs/automation.log ${DIR}
+  echo "=== Reports retrieved successfully ==="
+    
+else
+  #for all UNIX instances
+  ssh -o StrictHostKeyChecking=no -i ${key_pem} ${user}@${host} mkdir -p ${REM_DIR}
+  scp -o StrictHostKeyChecking=no -i ${key_pem} ${FILE1} ${user}@${host}:${REM_DIR}
+  scp -o StrictHostKeyChecking=no -i ${key_pem} ${FILE2} ${user}@${host}:${REM_DIR}
+  scp -o StrictHostKeyChecking=no -i ${key_pem} ${FILE3} ${user}@${host}:${REM_DIR}
+  scp -o StrictHostKeyChecking=no -i ${key_pem} ${FILE4} ${user}@${host}:${REM_DIR}
+  scp -o StrictHostKeyChecking=no -i ${key_pem} ${FILE5} ${user}@${host}:${REM_DIR}
+  scp -o StrictHostKeyChecking=no -i ${key_pem} ${FILE6} ${user}@${host}:${REM_DIR}
+  scp -o StrictHostKeyChecking=no -i ${key_pem} ${FILE7} ${user}@${host}:${REM_DIR}
 
-scp -o StrictHostKeyChecking=no -i ${key_pem} ${FILE3} ${user}@${host}:${REM_DIR}
+  echo "=== Files copied successfully ==="
 
-scp -o StrictHostKeyChecking=no -i ${key_pem} ${FILE4} ${user}@${host}:${REM_DIR}
+  ssh -o StrictHostKeyChecking=no -i ${key_pem} ${user}@${host} bash ${REM_DIR}/intg-test-runner.sh --wd ${REM_DIR}
 
-scp -o StrictHostKeyChecking=no -i ${key_pem} ${FILE5} ${user}@${host}:${REM_DIR}
-
-scp -o StrictHostKeyChecking=no -i ${key_pem} ${FILE6} ${user}@${host}:${REM_DIR}
-
-scp -o StrictHostKeyChecking=no -i ${key_pem} ${FILE7} ${user}@${host}:${REM_DIR}
-echo "=== Files copied success ==="
-
-ssh -o StrictHostKeyChecking=no -i ${key_pem} ${user}@${host} bash ${REM_DIR}/intg-test-runner.sh --wd ${REM_DIR}
-
-### Get the reports from integration test
-scp -o StrictHostKeyChecking=no -r -i ${key_pem} ${user}@${host}:${REM_DIR}/product-apim/modules/integration/tests-integration/tests-backend/target/surefire-reports .
-scp -o StrictHostKeyChecking=no -r -i ${key_pem} ${user}@${host}:${REM_DIR}/product-apim/modules/integration/tests-integration/tests-backend/target/logs/automation.log .
-echo "=== Reports are copied success ==="
-
+  #Get the reports from integration test
+  scp -o StrictHostKeyChecking=no -r -i ${key_pem} ${user}@${host}:${REM_DIR}/product-apim/modules/integration/tests-integration/tests-backend/target/surefire-reports .
+  scp -o StrictHostKeyChecking=no -r -i ${key_pem} ${user}@${host}:${REM_DIR}/product-apim/modules/integration/tests-integration/tests-backend/target/logs/automation.log .
+  echo "=== Reports are copied success ==="
+fi
 ##script ends
+


### PR DESCRIPTION
## Purpose
Previously run-scenario shell script was only dealing with UNIX instances. This provides option to access and execute commands in a Windows instance which is having OpenSSH.

## Approach
1. Decide default user for SSH based on the OS.
2. Receive password for the Windows instance from AWS using the key.
3. Execute SSH /SCP commands along with `sshpass` command (sshpass command passes the password when doing ssh)

## User stories
As a user, I should be able to provide details of a Windows instance and execute APIM integration tests in it.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes