### PR TITLE
Removing escape character from Remote Directory Windows URL

### DIFF
--- a/integration-tests/run-scenario.sh
+++ b/integration-tests/run-scenario.sh
@@ -115,7 +115,7 @@ case "${os}" in
         PROP_REMOTE_DIR=REMOTE_WORKSPACE_DIR_UNIX ;;
 esac
 
-REM_DIR=`grep -w "$PROP_REMOTE_DIR" ${FILE1} ${FILE2} | cut -d'=' -f2`
+REM_DIR=`grep -w "$PROP_REMOTE_DIR" ${FILE1} ${FILE2} | cut -d'=' -f2 | sed 's/\\//g'`
 
 #----------------------------------------------------------------------
 # wait till port 22 is opened for SSH


### PR DESCRIPTION
## Purpose
To remove escaping character ("\\") from the REM_DIR URL. 

## Approach
The value is stored in the property file with the escaping characters. Removing the escape character using a reg-ex when reading the property file.
## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes