### PR TITLE
Move escape-character removing step into Windows switch

### DIFF
--- a/integration-tests/run-scenario.sh
+++ b/integration-tests/run-scenario.sh
@@ -115,7 +115,7 @@ case "${os}" in
         PROP_REMOTE_DIR=REMOTE_WORKSPACE_DIR_UNIX ;;
 esac
 
-REM_DIR=`grep -w "$PROP_REMOTE_DIR" ${FILE1} ${FILE2} | cut -d'=' -f2 | sed 's/\\//g'`
+REM_DIR=`grep -w "$PROP_REMOTE_DIR" ${FILE1} ${FILE2} | cut -d'=' -f2`
 
 #----------------------------------------------------------------------
 # wait till port 22 is opened for SSH
@@ -135,6 +135,7 @@ if [ "${os}" = "Windows" ]; then
   sleep 4m #wait 4 minutes till Windows instance is configured and able to receive password using key file.
   set +o xtrace #avoid printing sensitive data in the next commands
   request_ec2_password $instance_id
+  REM_DIR=$(echo "$REM_DIR" | sed 's/\\//g')
   echo "Copying files to ${REM_DIR}.."
   sshpass -p "${password}" scp -q -o StrictHostKeyChecking=no ${FILE1} ${user}@${host}:${REM_DIR}
   sshpass -p "${password}" scp -q -o StrictHostKeyChecking=no ${FILE2} ${user}@${host}:${REM_DIR}


### PR DESCRIPTION
## Purpose
The escape character removal step is taking into Windows flow, since it is only required with Windows OpenSSH.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes