### PR TITLE
Remove 'call' command in Windows SSH step.

### DIFF
--- a/integration-tests/run-scenario.sh
+++ b/integration-tests/run-scenario.sh
@@ -148,7 +148,7 @@ if [ "${os}" = "Windows" ]; then
   echo "=== Files copied successfully ==="
   echo "Execution begins.. "
 
-  sshpass -p "${password}" ssh -o StrictHostKeyChecking=no ${user}@${host} call "${REM_DIR}/${FILE8}" ${REM_DIR}
+  sshpass -p "${password}" ssh -o StrictHostKeyChecking=no ${user}@${host} "${REM_DIR}/${FILE8}" ${REM_DIR}
   echo "=== End of execution ==="
   echo "Retrieving reports from instance.. "
   sshpass -p "${password}" scp -q -o StrictHostKeyChecking=no ${user}@${host}:${REM_DIR}/product-apim/modules/integration/tests-integration/tests-backend/target/surefire-reports ${DIR}


### PR DESCRIPTION
## Purpose
Remove 'call' command in Windows SSH step as it is not picking-up with OpenSSH.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes