### PR TITLE
fix to enable tests to be run on a provided branch

### DIFF
--- a/integration-tests/configure_product.py
+++ b/integration-tests/configure_product.py
@@ -25,7 +25,7 @@ import shutil
 import logging
 from const import ZIP_FILE_EXTENSION, NS, SURFACE_PLUGIN_ARTIFACT_ID, CARBON_NAME, VALUE_TAG, \
     DEFAULT_ORACLE_SID, DATASOURCE_PATHS, MYSQL_DB_ENGINE, ORACLE_DB_ENGINE, LIB_PATH, PRODUCT_STORAGE_DIR_NAME, \
-    DISTRIBUTION_PATH, MSSQL_DB_ENGINE
+    DISTRIBUTION_PATH, MSSQL_DB_ENGINE, POM_FILE_PATHS
 
 datasource_paths = None
 database_url = None
@@ -110,8 +110,14 @@ def modify_distribution_name(element):
 # However, in order to execute this method you can define pom file paths in const.py as a constant
 # and import it to configure_product.py. Thereafter assign it to global variable called pom_file_paths in the
 # configure_product method and call the modify_pom_files method.
-def modify_pom_files():
-    for pom in pom_file_paths:
+def modify_pom_files(id, wp, product):
+    global product_id
+    global workspace
+    global product_name
+    product_id = id
+    workspace = wp
+    product_name = product
+    for pom in POM_FILE_PATHS:
         file_path = Path(workspace + "/" + product_id + "/" + pom)
         if sys.platform.startswith('win'):
             file_path = winapi_path(file_path)

--- a/integration-tests/const.py
+++ b/integration-tests/const.py
@@ -23,6 +23,7 @@ DATASOURCE_PATHS = {"product-apim": ["repository/conf/datasources/master-datasou
                     "product-ei": []}
 DIST_POM_PATH = {"product-is": "modules/distribution/pom.xml", "product-apim": "modules/distribution/product/pom.xml",
                  "product-ei": "distribution/pom.xml"}
+POM_FILE_PATHS = {"modules/integration/tests-integration/tests-backend/pom.xml"}
 LIB_PATH = "repository/components/lib"
 DISTRIBUTION_PATH = {"product-apim": "modules/distribution/product/target",
                      "product-is": "modules/distribution/target",


### PR DESCRIPTION
## Purpose
Tests should be able to run with latest fixes of tests failures. To address this requirement user should be able to provide a flag which is to decide whether test run with the latest released tag or with a specific branch.

## Goals
Run APIM Integration tests and provide with the results

## Approach
Added new property 'runOnBranch' to provide a boolean value as a flag which will decide whether the test supposed to run on latest released tag or specific branch(master)
runOnBranch value should be added to any of property file and the value should be boolean.
