### PR TITLE
Attach jolokia agent to product-apim at runtime

### DIFF
--- a/integration-tests/configure_product.py
+++ b/integration-tests/configure_product.py
@@ -146,7 +146,7 @@ def modify_pom_files():
 
 def attach_jolokia_agent(spath):
     logger.info('attaching jolokia agent as a java agent')
-    sp=str(spath)
+    sp = str(spath)
     with open(sp, "r") as in_file:
         buf = in_file.readlines()
 

--- a/integration-tests/configure_product.py
+++ b/integration-tests/configure_product.py
@@ -25,7 +25,7 @@ import shutil
 import logging
 from const import ZIP_FILE_EXTENSION, NS, SURFACE_PLUGIN_ARTIFACT_ID, CARBON_NAME, VALUE_TAG, \
     DEFAULT_ORACLE_SID, DATASOURCE_PATHS, MYSQL_DB_ENGINE, ORACLE_DB_ENGINE, LIB_PATH, PRODUCT_STORAGE_DIR_NAME, \
-    DISTRIBUTION_PATH, MSSQL_DB_ENGINE, M2_PATH
+    DISTRIBUTION_PATH, MSSQL_DB_ENGINE, M2_PATH, WSO2SERVER
 
 datasource_paths = None
 database_url = None
@@ -144,6 +144,20 @@ def modify_pom_files():
         artifact_tree.write(file_path)
 
 
+def attach_jolokia_agent(spath):
+    logger.info('attaching jolokia agent as a java agent')
+    sp=str(spath)
+    with open(sp, "r") as in_file:
+        buf = in_file.readlines()
+
+    with open(sp, "w") as out_file:
+        for line in buf:
+            if line == "    $JAVACMD \\\n":
+                line = line + "    -javaagent:/opt/wso2/jolokia-jvm-1.6.0-agent.jar=port=8778,host=localhost,protocol=http \\\n"
+                logger.info(line)
+            out_file.write(line)
+
+
 def modify_datasources():
     """Modify datasources files which are defined in the const.py. DB ulr, uname, pwd, driver class values are modifying.
     """
@@ -231,8 +245,11 @@ def configure_product(name, id, db_config, ws, product_version):
         storage_zip_abs_path = Path(storage_dir_abs_path / zip_name)
         storage_dist_abs_path = Path(storage_dir_abs_path / dist_name)
         configured_dist_storing_loc = Path(target_dir_abs_path / dist_name)
+        script_name = Path(WSO2SERVER)
+        script_path = Path(storage_dist_abs_path / script_name)
 
         extract_product(storage_zip_abs_path)
+        attach_jolokia_agent(script_path)
         copy_jar_file(Path(database_config['sql_driver_location']), Path(storage_dist_abs_path / LIB_PATH))
 
         if datasource_paths is not None:

--- a/integration-tests/const.py
+++ b/integration-tests/const.py
@@ -30,6 +30,7 @@ DISTRIBUTION_PATH = {"product-apim": "modules/distribution/product/target",
                      "product-is": "modules/distribution/target",
                      "product-ei": "modules/distribution/target"}
 PRODUCT_STORAGE_DIR_NAME = "storage"
+WSO2SERVER = 'bin/wso2server.sh'
 TEST_PLAN_PROPERTY_FILE_NAME = "testplan-props.properties"
 INFRA_PROPERTY_FILE_NAME = "infrastructure.properties"
 LOG_FILE_NAME = "integration.log"

--- a/integration-tests/const.py
+++ b/integration-tests/const.py
@@ -30,7 +30,7 @@ DISTRIBUTION_PATH = {"product-apim": "modules/distribution/product/target",
                      "product-is": "modules/distribution/target",
                      "product-ei": "modules/distribution/target"}
 PRODUCT_STORAGE_DIR_NAME = "storage"
-WSO2SERVER = 'bin/wso2server.sh'
+WSO2SERVER = "bin/wso2server.sh"
 TEST_PLAN_PROPERTY_FILE_NAME = "testplan-props.properties"
 INFRA_PROPERTY_FILE_NAME = "infrastructure.properties"
 LOG_FILE_NAME = "integration.log"

--- a/integration-tests/run-intg-test.py
+++ b/integration-tests/run-intg-test.py
@@ -477,8 +477,10 @@ def get_latest_tag_name(product):
     """
     global tag_name
     git_path = Path(workspace + "/" + product)
-    binary_val_of_tag_name = subprocess.Popen(["git", "describe", "--abbrev=0", "--tags"],
-                                              stdout=subprocess.PIPE, cwd=git_path)
+    latest_rev = subprocess.Popen(["git", "rev-list", "--tags", "--max-count=1"], stdout=subprocess.PIPE, cwd=git_path)
+    binary_val_of_tag_name = subprocess.Popen(
+        ["git", "describe", "--tags", latest_rev.stdout.read().strip().decode("utf-8")], stdout=subprocess.PIPE,
+        cwd=git_path)
     tag_name = binary_val_of_tag_name.stdout.read().strip().decode("utf-8")
     return tag_name
 


### PR DESCRIPTION
## Purpose
The time period of the Grafana dashboard is set as last month. So it will not show data of previous months and the data is zoomed out to show data from whole month when there is only data of few hours. This PR is to resolve this 

## Goals
Visualize JVM metrics in Dashboard

## Approach
Attach Jolokia java agent which will pull JVM metrics from the JVM of the tested product. 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
