### PR TITLE
Avoid exiting before files are copied from remote server in run-scenario.sh

### DIFF
--- a/integration-tests/run-scenario.sh
+++ b/integration-tests/run-scenario.sh
@@ -235,6 +235,8 @@ if [ "${os}" = "Windows" ]; then
 
   echo "=== Files copied successfully ==="
   echo "Execution begins.. "
+  
+  set +e #avoid exiting before files are copied from remote server
 
   sshpass -p "${password}" ssh -o StrictHostKeyChecking=no ${user}@${host} "${REM_DIR}/${FILE8}" ${REM_DIR}
   echo "=== End of execution ==="
@@ -263,6 +265,8 @@ else
   fi
 
   echo "=== Files copied successfully ==="
+  
+  set +e #avoid exiting before files are copied from remote server
 
   ssh -o StrictHostKeyChecking=no -i ${key_pem} ${user}@${host} bash ${REM_DIR}/intg-test-runner.sh --wd ${REM_DIR}
 


### PR DESCRIPTION
## Purpose
> Contains improvements to run-scenarion.sh to copy files from remote server regardless of the test run failure.